### PR TITLE
Periodic cleanup and updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
+[report]
+show_missing = true
+
 [run]
+branch = True
+source = sbo_sphinx
 omit =
     */tests/*

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,13 @@
 sbo-sphinx Changelog
 ====================
 
+2.2.1 (2017-03-08)
+------------------
+* Fixed ``jsdoc_exclude`` under Python 3
+* Updated the default intersphinx link to Django documentation (from 1.6 to 1.10)
+* Verified support for Python 3.6
+* More accurate test coverage reporting
+
 2.2.0 (2015-09-22)
 ------------------
 * Cleaner EPUB output by default, including a default cover

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -3,10 +3,10 @@
 # Indirect dependencies first, exact versions for consistency
 
 # flake8
-mccabe==0.4.0
-pep8==1.7.0
-pyflakes==1.1.0
+mccabe==0.6.1
+pycodestyle==2.3.1
+pyflakes==1.5.0
 
 # And now the direct dependencies
 
-flake8==2.5.4
+flake8==3.3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,54 +1,64 @@
-# Core dependencies common to all Python interpreters
-
-# Python packaging utilities
-setuptools==20.2.2
-
-# Package manager, also used to parse this file in setup.py
-pip==8.0.3
-
 # Indirect dependencies first, exact versions for consistency
+
+# pip -> setuptools -> packaging
+pyparsing==2.2.0
+
+# pip -> setuptools
+appdirs==1.4.3
+packaging==16.8
+six==1.10.0
+
+# pip
+setuptools==34.3.1
 
 # readme_renderer -> bleach -> html5lib, Sphinx
 six==1.10.0
+
+# readme_renderer -> bleach -> html5lib
+webencodings==0.5
 
 # readme_renderer -> bleach
 html5lib==0.9999999
 
 # readme_renderer
-bleach==1.4.2
+bleach==1.5.0
 
 # readme_renderer, Sphinx
-docutils==0.12
-Pygments==2.1.3
+docutils==0.13.1
+Pygments==2.2.0
 
 # recommonmark
 CommonMark==0.5.4
 
 # Sphinx -> Babel
-pytz==2015.7
+pytz==2016.10
 
 # Sphinx -> Jinja2
-MarkupSafe==0.23
+MarkupSafe==1.0
 
 # Sphinx -> snowballstemmer; optional dependency for better performance
 PyStemmer==1.3.0
 
 # Sphinx
-Babel==2.2.0
-Jinja2==2.8
+Babel==2.3.4
+imagesize==0.7.1
+Jinja2==2.9.5
 snowballstemmer==1.2.1
 
 # And now the direct dependencies
 
+# Package manager
+pip==9.0.1
+
 # The README parser used by PyPI, used to validate README.rst
-readme_renderer==0.7.0
+readme_renderer==16.0
 
 # A docutils extension to support parsing CommonMark-flavored Markdown
 recommonmark==0.4.0
 
 # Documentation generator
-Sphinx==1.3.6
+Sphinx==1.5.3
 
 # Sphinx themes (circular dependencies of Sphinx)
-alabaster==0.7.7
-sphinx_rtd_theme==0.1.9
+alabaster==0.7.10
+sphinx_rtd_theme==0.2.4

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,43 +2,43 @@
 
 # Indirect dependencies first, exact versions for consistency
 
-# ipdb -> ipython -> pickleshare
-path.py==8.1.2
+# ipdb -> ipython -> pexpect
+ptyprocess==0.5.1; sys_platform != 'win32'
+
+# ipdb -> ipython -> prompt_toolkit
+wcwidth==0.1.7
 
 # ipdb -> ipython -> traitlets
-decorator==4.0.9
+decorator==4.0.11
 ipython-genutils==0.1.0
 
 # ipdb -> ipython
 appnope==0.1.0; sys_platform == 'darwin'
-gnureadline==6.3.3; sys_platform == 'darwin'
-pexpect==4.0.1; sys_platform != 'win32'
-pickleshare==0.6
+pexpect==4.2.1; sys_platform != 'win32'
+pickleshare==0.7.4
+prompt_toolkit==1.0.13
 simplegeneric==0.8.1
-traitlets==4.1.0
+traitlets==4.3.2
 
 # ipdb
-ipython==4.1.2
-
-# pytest-cov -> cov-core
-coverage==4.0.3
+ipython==5.3.0
 
 # pytest-cov -> pytest
-py==1.4.31
+py==1.4.32
 
 # pytest-catchlog, pytest-cov
-pytest==2.9.0
-
-# pytest-cov
-cov-core==1.15.0
+pytest==3.0.6
 
 # Direct dependencies for running tests
 
+# Includes a backport of redirect_stdout for Python 2
+contextlib2==0.5.4; python_version < '3.4'
+
 # A better debugger
-ipdb==0.9.0
+ipdb==0.10.2
 
 # Show log output for test failures
 pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
-pytest-cov==2.2.1
+coverage==4.3.4

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -2,9 +2,9 @@
 # Installed by Jenkins and dev environments.
 
 # tox dependencies
-pluggy==0.3.1
-py==1.4.31
-virtualenv==14.0.6
+pluggy==0.4.0
+py==1.4.32
+virtualenv==15.1.0
 
 # For managing test environments
-tox==2.3.1
+tox==2.6.0

--- a/requirements/uninstall.txt
+++ b/requirements/uninstall.txt
@@ -1,3 +1,6 @@
 # Packages which were once dependencies, but should now be removed if present.
 
+cov-core
+gnureadline
 nose
+pytest-cov

--- a/sbo_sphinx/conf.py
+++ b/sbo_sphinx/conf.py
@@ -360,7 +360,7 @@ epub_show_urls = 'no'
 # Example configuration for intersphinx
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2/', None),
-    'django': ('https://docs.djangoproject.com/en/1.6/', 'http://docs.djangoproject.com/en/1.6/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/1.10/', 'https://docs.djangoproject.com/en/1.10/_objects/'),
     'sphinx': ('http://sphinx-doc.org/', None),
 }
 

--- a/sbo_sphinx/jsdoc.py
+++ b/sbo_sphinx/jsdoc.py
@@ -26,6 +26,8 @@ intermediate files aren't accidentally committed.
 External requirements: java, ant
 """
 
+from __future__ import unicode_literals
+
 import os
 from shutil import rmtree
 from subprocess import Popen
@@ -65,7 +67,7 @@ def generate_docs(app):
                '-Djs.src.dir=%s' % javascript_root,
                '-Djs.rst.dir=%s' % output_root]
     if exclude:
-        exclude_args = ['--exclude=\\"%s\\"' % path for path in exclude]
+        exclude_args = ['--exclude=\"%s\"' % path for path in exclude]
         command.append('-Djs.exclude="%s"' % ' '.join(exclude_args))
     try:
         process = Popen(command, cwd=execution_dir)

--- a/sbo_sphinx/tests/test_output.py
+++ b/sbo_sphinx/tests/test_output.py
@@ -6,8 +6,15 @@ from __future__ import unicode_literals
 
 import os
 from shutil import rmtree
-from subprocess import PIPE, Popen, STDOUT
 from unittest import TestCase
+
+import six
+import sphinx
+
+try:
+    from contextlib import redirect_stdout
+except ImportError:
+    from contextlib2 import redirect_stdout
 
 DOCS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                         '..', '..', 'docs'))
@@ -29,12 +36,11 @@ class TestOutput(TestCase):
 
     def test_html(self):
         """The HTML output should build correctly"""
-        process = Popen(['sphinx-build', '-b', 'html', '.', '_test'],
-                        cwd=DOCS_DIR,
-                        stderr=STDOUT,
-                        stdout=PIPE,
-                        universal_newlines=True)
-        output, _ = process.communicate()
+        output_stream = six.moves.cStringIO()
+        with redirect_stdout(output_stream):
+            exit_code = sphinx.build_main(['sphinx-build', '-b', 'html', DOCS_DIR, OUTPUT_DIR])
+        assert exit_code == 0
+        output = six.text_type(output_stream.getvalue())
         self._verify_intermediate_files(output)
         expected = [
             os.path.join('_static', 'favicon.ico'),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ finder = PackageFinder([], [], session=session)
 requirements = parse_requirements(requirements_path, finder, session=session)
 install_requires = [r.name for r in requirements]
 
-version = '2.2.0'  # Don't forget to update docs/CHANGELOG.rst if you increment the version
+version = '2.2.1'  # Don't forget to update docs/CHANGELOG.rst if you increment the version
 
 with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()
@@ -33,6 +33,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py{27,34,35}
+envlist = py{27,34,35,36}
 
 [pytest]
-addopts = --cov sbo_sphinx --cov-report term-missing
 norecursedirs = .* docs requirements ve
 
 [testenv]
@@ -10,14 +9,14 @@ deps = -r{toxinidir}/requirements/base.txt
 commands =
     {toxinidir}/requirements/clean_up_requirements.py
     pip install --requirement requirements/base.txt --quiet
-    python setup.py --quiet develop --always-unzip
     pip install --requirement requirements/tests.txt --quiet
-    py.test {posargs}
+    coverage run -m pytest {posargs:sbo_sphinx}
+    coverage report
 
 [testenv:audit]
 commands =
     pip --trusted-host pypi.safaribooks.com --disable-pip-version-check install --allow-all-external --find-links http://pypi.safaribooks.com/packages/ --allow-unverified audit-python-package --upgrade --quiet audit-python-package readme
-    py.test --pyargs audit_python_package -k "not TestDocumentationRequirements and not test_docs_installs_documentation_dependencies and not test_prevent_pypi_upload and not test_environment_markers"
+    pytest --pyargs audit_python_package -k "not TestDocumentationRequirements and not test_docs_installs_documentation_dependencies and not test_prevent_pypi_upload and not test_environment_markers"
     python setup.py check --restructuredtext --strict --metadata
 
 [testenv:docs]


### PR DESCRIPTION
Found a problem with the intersphinx configuration while working on django-nose-qunit, and made some updates:

* Fixed ``jsdoc_exclude`` under Python 3
* Updated the default intersphinx link to Django documentation (from 1.6 to 1.10)
* Verified support for Python 3.6
* More accurate test coverage reporting
* Updated dependencies for dev environments and test runs
